### PR TITLE
Change thread ID type to usize

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "thread-id"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Ruud van Asseldonk <dev@veniogames.com>"]
 license = "Apache-2.0"
 readme = "readme.md"
 keywords = ["thread", "pthread", "getcurrentthreadid"]
 description = "Get a unique thread ID"
 repository = "https://github.com/ruud-v-a/thread-id"
-documentation = "https://ruud-v-a.github.io/thread-id/doc/v1.0.0/thread-id/"
+documentation = "https://ruud-v-a.github.io/thread-id/doc/v2.0.0/thread-id/"
 
 [dependencies]
 libc = "0.2.6"

--- a/readme.md
+++ b/readme.md
@@ -42,6 +42,6 @@ to your copyright notice.
 [crate-img]: http://img.shields.io/crates/v/thread-id.svg
 [crate]:     https://crates.io/crates/thread-id
 [docs-img]:  http://img.shields.io/badge/docs-online-blue.svg
-[docs]:      https://ruud-v-a.github.io/thread-id/doc/v1.0.0/thread-id/
+[docs]:      https://ruud-v-a.github.io/thread-id/doc/v2.0.0/thread-id/
 [apache2]:   https://www.apache.org/licenses/LICENSE-2.0
 [except]:    https://www.gnu.org/licenses/gpl-faq.html#GPLIncompatibleLibs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,18 +36,18 @@ extern crate kernel32;
 /// Calling this function twice from the same thread will return the same
 /// number. Calling this function from a different thread will return a
 /// different number.
-pub fn get() -> u64 {
+pub fn get() -> usize {
     get_internal()
 }
 
 #[cfg(unix)]
-fn get_internal() -> u64 {
-    unsafe { libc::pthread_self() as u64 }
+fn get_internal() -> usize {
+    unsafe { libc::pthread_self() as usize }
 }
 
 #[cfg(windows)]
-fn get_internal() -> u64 {
-    unsafe { kernel32::GetCurrentThreadId() as u64 }
+fn get_internal() -> usize {
+    unsafe { kernel32::GetCurrentThreadId() as usize }
 }
 
 #[test]


### PR DESCRIPTION
This allows the returned value to be used with `AtomicUsize`, which is useful for certain lock-free algorithms that need a thread ID.

I also marked the functions as inline since they are very short (`GetCurrentThreadId` is 3 instructions, `pthread_self` is 2 instructions), which makes the additional call/return overhead significant.

Since this is a breaking change the version has been bumped to 2.0.0.
