### PR TITLE
Mark functions as inline

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,16 +36,19 @@ extern crate kernel32;
 /// Calling this function twice from the same thread will return the same
 /// number. Calling this function from a different thread will return a
 /// different number.
+#[inline]
 pub fn get() -> u64 {
     get_internal()
 }
 
 #[cfg(unix)]
+#[inline]
 fn get_internal() -> u64 {
     unsafe { libc::pthread_self() as u64 }
 }
 
 #[cfg(windows)]
+#[inline]
 fn get_internal() -> u64 {
     unsafe { kernel32::GetCurrentThreadId() as u64 }
 }


### PR DESCRIPTION
The called functions are very short (GetCurrentThreadId is 3 instructions, pthread_self is 2 instructions), which makes the additional call/return overhead significant.
